### PR TITLE
Eliminate obsolete parameter allow_pending_state for azure_server_farm_with_rich_sku; Fix dependencies for elastic_pool_name for azure_sql_database

### DIFF
--- a/lib/puppet/provider/azure_server_farm_with_rich_sku/azure_server_farm_with_rich_sku.rb
+++ b/lib/puppet/provider/azure_server_farm_with_rich_sku/azure_server_farm_with_rich_sku.rb
@@ -268,7 +268,6 @@ Puppet::Type.type(:azure_server_farm_with_rich_sku).provide(:arm) do
     header_params["User-Agent"] = "puppetlabs-azure_arm/0.2.1"
 
     op_params = [
-      self.op_param("allowPendingState", "query", "allow_pending_state", "allow_pending_state"),
       self.op_param("api-version", "query", "api_version", "api_version"),
       self.op_param("id", "body", "id", "id"),
       self.op_param("kind", "body", "kind", "kind"),
@@ -309,7 +308,6 @@ Puppet::Type.type(:azure_server_farm_with_rich_sku).provide(:arm) do
     header_params["User-Agent"] = "puppetlabs-azure_arm/0.2.1"
 
     op_params = [
-      self.op_param("allowPendingState", "query", "allow_pending_state", "allow_pending_state"),
       self.op_param("api-version", "query", "api_version", "api_version"),
       self.op_param("id", "body", "id", "id"),
       self.op_param("kind", "body", "kind", "kind"),

--- a/lib/puppet/provider/azure_sql_database/azure_sql_database.rb
+++ b/lib/puppet/provider/azure_sql_database/azure_sql_database.rb
@@ -281,7 +281,7 @@ Puppet::Type.type(:azure_sql_database).provide(:arm) do
         path_params[name_snake.to_sym] = resource[paramalias.to_sym] unless resource.nil? || resource[paramalias.to_sym].nil?
       end
     end
-    self.call_op(path_params, query_params, header_params, body_params, "management.azure.com", "/subscriptions/%{subscription_id}/resourceGroups/%{resource_group_name}/providers/Microsoft.Sql/servers/%{server_name}/elasticPools/%{elastic_pool_name}/databases", "Get", "[application/json]")
+    defined?(elastic_pool_name) && self.call_op(path_params, query_params, header_params, body_params, "management.azure.com", "/subscriptions/%{subscription_id}/resourceGroups/%{resource_group_name}/providers/Microsoft.Sql/servers/%{server_name}/elasticPools/%{elastic_pool_name}/databases", "Get", "[application/json]")
   end
 
   def self.invoke_get_one(resource = nil, body_params = nil)
@@ -322,7 +322,7 @@ Puppet::Type.type(:azure_sql_database).provide(:arm) do
         path_params[name_snake.to_sym] = resource[paramalias.to_sym] unless resource.nil? || resource[paramalias.to_sym].nil?
       end
     end
-    self.call_op(path_params, query_params, header_params, body_params, "management.azure.com", "/subscriptions/%{subscription_id}/resourceGroups/%{resource_group_name}/providers/Microsoft.Sql/servers/%{server_name}/recommendedElasticPools/%{recommended_elastic_pool_name}/databases/%{database_name}", "Get", "[application/json]")
+    defined?(recommended_elastic_pool_name) && self.call_op(path_params, query_params, header_params, body_params, "management.azure.com", "/subscriptions/%{subscription_id}/resourceGroups/%{resource_group_name}/providers/Microsoft.Sql/servers/%{server_name}/recommendedElasticPools/%{recommended_elastic_pool_name}/databases/%{database_name}", "Get", "[application/json]")
   end
 
   def self.authenticate(path_params, query_params, header_params, body_params)

--- a/lib/puppet/type/azure_sql_database.rb
+++ b/lib/puppet/type/azure_sql_database.rb
@@ -10,9 +10,7 @@ Puppet::Type.newtype(:azure_sql_database) do
   validate do
     required_properties = [
       :location,
-      :elastic_pool_name,
       :parameters,
-      :recommended_elastic_pool_name,
       :resource_group_name,
       :server_name,
     ]
@@ -21,6 +19,18 @@ Puppet::Type.newtype(:azure_sql_database) do
       if self[:ensure] == :present && self[property].nil? && self.provider.send(property) == :absent
         raise Puppet::Error, "In azure_sql_database you must provide a value for #{property}"
       end
+    end
+  end
+  newproperty(:elastic_pool_name) do
+    desc "Elastic Pool Name."
+    validate do |value|
+      true
+    end
+  end
+  newproperty(:recommended_elastic_pool_name) do
+    desc "Recommended Elastic Pool Name."
+    validate do |value|
+      true
     end
   end
   newproperty(:id) do


### PR DESCRIPTION
The provider "azure_server_farm_with_rich_sku" was requiring an obsolete parameter "allow_pending_state" despite the fact that such a parameter was not allowed for this type.  Eliminating this parameter allows deploys to complete successfully.

Also, "azure_sql_database" was erroneously requiring "elastic_pool_name" and "recommended_pool_name", which are both optional parameters.  It also failed trying to retrieve an ElasticPool when none existed.  I removed both parameters from the "required" list and had the provider only check on ElasticPools if the elastic_pool_name or recommended_elastic_pool_name parameters were specified.